### PR TITLE
chore(github): add fix yaml template and please release workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/fix_report.yaml
+++ b/.github/ISSUE_TEMPLATE/fix_report.yaml
@@ -1,0 +1,28 @@
+name: ✨ Fix
+description: File a fix, typo, polish or an aesthetic rather than functional improvement request
+title: "[FIX](page scope): fix 'replace me'"
+labels: [fix, triage]
+assignees: guilbep
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,13 @@
+on:
+  push:
+    branches:
+      - dev
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: release-please-action


### PR DESCRIPTION
# Describe your changes

- Add please-release github action for automatic release creation
  - We setup the trigger branch to 'dev' instead of 'main' because we will do releases to the test platform (dev branch) and we want to be able to have release in dev.
  - The main branch will reflect the production code (on unhcr-tss.epfl.ch)
  - The dev branch will reflect the dev code (on unhcr-tss-test.epfl.ch)
- Add new issue template for github for fix/polish


# Related GitHub issues and pull requests

- Ref: #73 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] Don't forget to link PR to issue if you are solving one.
