### PR TITLE
fix(shelter): truncate sankey label to avoid overflowing labels

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -321,6 +321,11 @@ export default class App extends Vue {
 }
 
 @media print {
+  * {
+    -webkit-print-color-adjust: exact; /* Chrome, Safari 6 – 15.3, Edge */
+    color-adjust: exact; /* Firefox 48 – 96 */
+    print-color-adjust: exact; /* Firefox 97+, Safari 15.4+ */
+  }
   .v-application .v-app-bar,
   .v-application .v-navigation-drawer {
     display: none;
@@ -331,6 +336,9 @@ export default class App extends Vue {
     margin: -1em;
     padding: 0;
     width: 100%;
+  }
+  .pagebreak {
+    page-break-before: always;
   }
 }
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -320,6 +320,20 @@ export default class App extends Vue {
   --c-unhcr: var(--v-primary-base);
 }
 
+@media print {
+  .v-application .v-app-bar,
+  .v-application .v-navigation-drawer {
+    display: none;
+  }
+
+  @page {
+    size: A4;
+    margin: -1em;
+    padding: 0;
+    width: 100%;
+  }
+}
+
 .project__header,
 .project__h3 {
   color: var(--c-shelter);

--- a/frontend/src/components/shelter_sustainability/billOfQuantities/graphTree.vue
+++ b/frontend/src/components/shelter_sustainability/billOfQuantities/graphTree.vue
@@ -288,6 +288,12 @@ export default class GraphTree extends Vue {
         color: "source",
         curveness: 0.5,
       },
+      label: {
+        fontSize: 7,
+        align: "left",
+        overflow: "break",
+        width: "70",
+      },
     };
     return {
       tooltip: {

--- a/frontend/src/components/shelter_sustainability/billOfQuantities/graphTree.vue
+++ b/frontend/src/components/shelter_sustainability/billOfQuantities/graphTree.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-responsive v-bind="{ ...$attrs, ...$props }">
+  <v-responsive v-bind="{ ...$attrs, ...$props }" class="justify-center">
     <v-chart autoresize :option="option"></v-chart>
   </v-responsive>
 </template>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -14,6 +14,7 @@ import router from "./router";
 import store from "./store";
 
 Vue.config.productionTip = false;
+Vue.prototype.window = window;
 
 Vue.use(User, { store });
 Vue.use(filters);

--- a/frontend/src/views/shelter_sustainability/ShelterSustainability.vue
+++ b/frontend/src/views/shelter_sustainability/ShelterSustainability.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container fluid>
-    <v-tabs>
+    <v-tabs class="d-print-none">
       <v-tab :to="{ name: 'ShelterSustainabilityList', query: $route.query }"
         >All shelters</v-tab
       >

--- a/frontend/src/views/shelter_sustainability/ShelterSustainabilityCompare.vue
+++ b/frontend/src/views/shelter_sustainability/ShelterSustainabilityCompare.vue
@@ -13,17 +13,26 @@
     <v-row v-else>
       <v-col>
         <v-row>
-          <v-col cols="3"></v-col>
+          <v-col cols="3">
+            <v-btn
+              class="d-print-none"
+              @click="
+                window.print();
+                return false;
+              "
+              >Print</v-btn
+            >
+          </v-col>
           <v-col>
             <v-row>
               <v-col v-for="shelter in shelters" :key="shelter._id">
                 <v-row>
-                  <v-col>
+                  <v-col class="d-flex justify-center">
                     {{ shelter.name }}
                   </v-col>
                 </v-row>
                 <v-row>
-                  <v-col>
+                  <v-col class="d-flex justify-center">
                     <v-icon
                       :class="`c-${shelterColors[shelter.shelter_type].name}`"
                     >
@@ -43,7 +52,11 @@
           <v-col>
             <v-row>
               <v-col cols="3" class="ml-4">Intended occupants</v-col>
-              <v-col v-for="shelter in shelters" :key="shelter._id">
+              <v-col
+                v-for="shelter in shelters"
+                :key="shelter._id"
+                class="d-flex justify-center"
+              >
                 <v-icon
                   v-for="n in shelter.shelter_occupants"
                   :key="n"
@@ -56,18 +69,23 @@
             </v-row>
             <v-row>
               <v-col cols="3" class="ml-4">Intended lifespan</v-col>
-              <v-col v-for="shelter in shelters" :key="shelter._id">
+              <v-col
+                v-for="shelter in shelters"
+                :key="shelter._id"
+                class="d-flex justify-center"
+              >
                 {{ shelter.shelter_lifespan }} year(s)
               </v-col>
             </v-row>
             <v-row>
               <v-col cols="3" class="ml-4">Setup</v-col>
-              <v-col v-for="shelter in shelters" :key="shelter._id">
-                <div class="flex align-center">
-                  <!-- todo: use filter for plural for day(s) -->
-                  {{ shelter.setup_people }} ppl x
-                  {{ shelter.setup_time }} day(s)
-                </div>
+              <v-col
+                v-for="shelter in shelters"
+                :key="shelter._id"
+                class="d-flex justify-center"
+              >
+                <!-- todo: use filter for plural for day(s) -->
+                {{ shelter.setup_people }} ppl x {{ shelter.setup_time }} day(s)
               </v-col>
             </v-row>
             <v-row
@@ -102,9 +120,9 @@
               <v-col
                 v-for="shelter in shelters"
                 :key="shelter._id"
-                class="d-flex"
+                class="d-flex justify-center"
               >
-                <v-layout class="align-center">
+                <v-layout class="align-center d-flex justify-center">
                   <span>
                     {{ shelter.scorecard[affordability.id] | formatNumber() }}
                     {{ affordability.unit }}
@@ -122,10 +140,14 @@
         <v-row>
           <v-col>
             <v-row>
-              <v-col cols="3" class="ml-4 ml-4 col col-3 d-flex align-center"
+              <v-col cols="3" class="ml-4 col col-3 d-flex align-center"
                 >Shape</v-col
               >
-              <v-col v-for="shelter in shelters" :key="shelter._id">
+              <v-col
+                v-for="shelter in shelters"
+                :key="shelter._id"
+                class="d-flex justify-center"
+              >
                 <v-img
                   v-if="shelter.geometry.shelter_geometry_type"
                   max-width="150px"
@@ -146,9 +168,15 @@
             </v-row>
             <v-row>
               <v-col cols="3" class="ml-4">Volume</v-col>
-              <v-col v-for="shelter in shelters" :key="shelter._id">
-                {{ shelter.geometry.floorArea }} m<sup>2</sup>,
-                {{ shelter.geometry.volume }} m<sup>3</sup>
+              <v-col
+                v-for="shelter in shelters"
+                :key="shelter._id"
+                class="d-flex justify-center"
+              >
+                <div>
+                  {{ shelter.geometry.floorArea }} m<sup>2</sup>,
+                  {{ shelter.geometry.volume }} m<sup>3</sup>
+                </div>
               </v-col>
             </v-row>
             <v-row
@@ -183,19 +211,17 @@
               <v-col
                 v-for="shelter in shelters"
                 :key="shelter._id"
-                class="d-flex"
+                class="d-flex justify-center align-center"
               >
-                <v-layout class="align-center">
-                  <span>
-                    {{
-                      shelter.scorecard[constructionImpact.id] |
-                        formatNumber({
-                          style: "percent",
-                          maximumFractionDigits: 0,
-                        })
-                    }}
-                  </span>
-                </v-layout>
+                <span>
+                  {{
+                    shelter.scorecard[constructionImpact.id] |
+                      formatNumber({
+                        style: "percent",
+                        maximumFractionDigits: 0,
+                      })
+                  }}
+                </span>
               </v-col>
             </v-row>
           </v-col>
@@ -213,7 +239,7 @@
               :key="environmentalImpact.id"
               style="border-bottom: 1px solid grey"
             >
-              <v-col cols="3" class="d-flex flex-column justify-center">
+              <v-col cols="3" class="ml-4 d-flex flex-column justify-center">
                 <div>
                   {{ environmentalImpact.title }}:
                   <info-tooltip right :max-width="300" :bottom="false"

--- a/frontend/src/views/shelter_sustainability/ShelterSustainabilityCompare.vue
+++ b/frontend/src/views/shelter_sustainability/ShelterSustainabilityCompare.vue
@@ -23,23 +23,23 @@
               >Print</v-btn
             >
           </v-col>
-          <v-col>
+          <v-col
+            v-for="shelter in shelters"
+            :key="shelter._id"
+            :cols="Math.floor(9 / shelters.length)"
+          >
             <v-row>
-              <v-col v-for="shelter in shelters" :key="shelter._id">
-                <v-row>
-                  <v-col class="d-flex justify-center">
-                    {{ shelter.name }}
-                  </v-col>
-                </v-row>
-                <v-row>
-                  <v-col class="d-flex justify-center">
-                    <v-icon
-                      :class="`c-${shelterColors[shelter.shelter_type].name}`"
-                    >
-                      {{ shelterIcons[shelter.shelter_type] }}
-                    </v-icon>
-                  </v-col>
-                </v-row>
+              <v-col class="d-flex justify-center">
+                {{ shelter.name }}
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col class="d-flex justify-center">
+                <v-icon
+                  :class="`c-${shelterColors[shelter.shelter_type].name}`"
+                >
+                  {{ shelterIcons[shelter.shelter_type] }}
+                </v-icon>
               </v-col>
             </v-row>
           </v-col>
@@ -51,11 +51,12 @@
         <v-row>
           <v-col>
             <v-row>
-              <v-col cols="3" class="ml-4">Intended occupants</v-col>
+              <v-col cols="3" class="ml-screen-4">Intended occupants</v-col>
               <v-col
                 v-for="shelter in shelters"
                 :key="shelter._id"
                 class="d-flex justify-center"
+                :cols="Math.floor(9 / shelters.length)"
               >
                 <v-icon
                   v-for="n in shelter.shelter_occupants"
@@ -68,21 +69,23 @@
               </v-col>
             </v-row>
             <v-row>
-              <v-col cols="3" class="ml-4">Intended lifespan</v-col>
+              <v-col cols="3" class="ml-screen-4">Intended lifespan</v-col>
               <v-col
                 v-for="shelter in shelters"
                 :key="shelter._id"
                 class="d-flex justify-center"
+                :cols="Math.floor(9 / shelters.length)"
               >
                 {{ shelter.shelter_lifespan }} year(s)
               </v-col>
             </v-row>
             <v-row>
-              <v-col cols="3" class="ml-4">Setup</v-col>
+              <v-col cols="3" class="ml-screen-4">Setup</v-col>
               <v-col
                 v-for="shelter in shelters"
                 :key="shelter._id"
                 class="d-flex justify-center"
+                :cols="Math.floor(9 / shelters.length)"
               >
                 <!-- todo: use filter for plural for day(s) -->
                 {{ shelter.setup_people }} ppl x {{ shelter.setup_time }} day(s)
@@ -92,7 +95,7 @@
               v-for="(affordability, idx) in affordabilities"
               :key="affordability.id"
             >
-              <v-col cols="3" class="ml-4">
+              <v-col cols="3" class="ml-screen-4">
                 <v-row
                   ><v-col>
                     {{ affordability.title }}:
@@ -121,6 +124,7 @@
                 v-for="shelter in shelters"
                 :key="shelter._id"
                 class="d-flex justify-center"
+                :cols="Math.floor(9 / shelters.length)"
               >
                 <v-layout class="align-center d-flex justify-center">
                   <span>
@@ -140,18 +144,20 @@
         <v-row>
           <v-col>
             <v-row>
-              <v-col cols="3" class="ml-4 col col-3 d-flex align-center"
+              <v-col cols="3" class="ml-screen-4 col col-3 d-flex align-center"
                 >Shape</v-col
               >
               <v-col
                 v-for="shelter in shelters"
                 :key="shelter._id"
                 class="d-flex justify-center"
+                :cols="Math.floor(9 / shelters.length)"
               >
                 <v-img
                   v-if="shelter.geometry.shelter_geometry_type"
                   max-width="150px"
                   max-height="150px"
+                  aspect-ratio="1"
                   class="d-flex justify-center white-background"
                   :src="
                     geometriesUrl[
@@ -167,11 +173,12 @@
               </v-col>
             </v-row>
             <v-row>
-              <v-col cols="3" class="ml-4">Volume</v-col>
+              <v-col cols="3" class="ml-screen-4">Volume</v-col>
               <v-col
                 v-for="shelter in shelters"
                 :key="shelter._id"
                 class="d-flex justify-center"
+                :cols="Math.floor(9 / shelters.length)"
               >
                 <div>
                   {{ shelter.geometry.floorArea }} m<sup>2</sup>,
@@ -183,7 +190,7 @@
               v-for="(constructionImpact, idx) in constructionImpacts"
               :key="constructionImpact.id"
             >
-              <v-col cols="3" class="ml-4">
+              <v-col cols="3" class="ml-screen-4">
                 <v-row>
                   <v-col>
                     {{ constructionImpact.title }}:
@@ -212,6 +219,7 @@
                 v-for="shelter in shelters"
                 :key="shelter._id"
                 class="d-flex justify-center align-center"
+                :cols="Math.floor(9 / shelters.length)"
               >
                 <span>
                   {{
@@ -229,7 +237,7 @@
         <!-- END OF CONSTRUCTION -->
 
         <!-- BEGIN ENVIRONMENTAL IMPACT -->
-        <v-row
+        <v-row class="pagebreak"
           ><v-col><b>ENVIRONMENTAL IMPACT</b></v-col></v-row
         >
         <v-row>
@@ -239,7 +247,10 @@
               :key="environmentalImpact.id"
               style="border-bottom: 1px solid grey"
             >
-              <v-col cols="3" class="ml-4 d-flex flex-column justify-center">
+              <v-col
+                cols="3"
+                class="ml-screen-4 d-flex flex-column justify-center"
+              >
                 <div>
                   {{ environmentalImpact.title }}:
                   <info-tooltip right :max-width="300" :bottom="false"
@@ -260,9 +271,16 @@
                   </v-responsive>
                 </div>
               </v-col>
-              <v-col v-for="shelter in shelters" :key="shelter._id">
+              <v-col
+                v-for="shelter in shelters"
+                :key="shelter._id"
+                :cols="Math.floor(9 / shelters.length)"
+              >
                 <v-row>
-                  <v-col class="text-center">
+                  <v-col
+                    cols="12"
+                    class="text-center d-flex justify-center align-center"
+                  >
                     <span>
                       {{
                         shelter.scorecard[environmentalImpact.id] |
@@ -273,7 +291,7 @@
                   </v-col>
                 </v-row>
                 <v-row>
-                  <v-col>
+                  <v-col cols="12" class="d-flex justify-center align-center">
                     <graph-tree
                       max-height="150px"
                       min-height="150px"


### PR DESCRIPTION
# Describe your changes

Overflow set to Break word for sankeys labels to avoid non-displayed label overflowing to the right of the graph.
<img width="1385" alt="BreakWord" src="https://user-images.githubusercontent.com/161889/211272111-492c83da-dc16-48ee-9506-98ae65e4257c.png">

# Related GitHub issues and pull requests

- Ref: #147

