### PR TITLE
fix(shelter): round volume to 2 decimal #159

### DIFF
--- a/frontend/src/views/shelter_sustainability/ShelterSustainabilityCompare.vue
+++ b/frontend/src/views/shelter_sustainability/ShelterSustainabilityCompare.vue
@@ -181,8 +181,8 @@
                 :cols="Math.floor(9 / shelters.length)"
               >
                 <div>
-                  {{ shelter.geometry.floorArea }} m<sup>2</sup>,
-                  {{ shelter.geometry.volume }} m<sup>3</sup>
+                  {{ shelter.geometry.floorArea | formatNumber }} m<sup>2</sup>,
+                  {{ shelter.geometry.volume | formatNumber }} m<sup>3</sup>
                 </div>
               </v-col>
             </v-row>


### PR DESCRIPTION
Avoid 10 decimal values for surface and volumes of shelter in the compare view

# Related GitHub issues and pull requests

- Ref: #159 
