### PR TITLE
fix(frontend): favor remote instead of local when retrieving item

### DIFF
--- a/frontend/src/store/GhgModule.ts
+++ b/frontend/src/store/GhgModule.ts
@@ -362,16 +362,16 @@ const actions: ActionTree<ProjectsState, RootState> = {
   getDoc: async (context: ActionContext<ProjectsState, RootState>, id) => {
     const db = context.state.localCouch?.remoteDB;
     const localDB = context.state.localCouch?.localDB; // for guest user only
-    if (localDB) {
+    if (db) {
       context.commit("SET_PROJECT_LOADING", true);
       try {
-        const result = await localDB.get(id);
+        const result = await db.get(id);
         context.commit("SET_PROJECT", result);
         return result;
       } catch (errL: unknown) {
         try {
-          if (db) {
-            const result = await db.get(id);
+          if (localDB) {
+            const result = await localDB.get(id);
             context.commit("SET_PROJECT", result);
             return result;
           }

--- a/frontend/src/store/ShelterModule.ts
+++ b/frontend/src/store/ShelterModule.ts
@@ -340,13 +340,13 @@ const actions: ActionTree<ShelterState, RootState> = {
     const db = context.state.localCouch?.remoteDB;
     const localDB = context.state.localCouch?.localDB; // for guest user only
     let result: Shelter | undefined;
-    if (localDB) {
+    if (db) {
       try {
-        result = await localDB.get(id);
+        result = await db.get(id);
       } catch (errL: unknown) {
         try {
-          if (db) {
-            result = await db.get(id);
+          if (localDB) {
+            result = await localDB.get(id);
           }
         } catch (err: unknown) {
           if (err instanceof Error) {


### PR DESCRIPTION
When the user is a guest, we should always try to retrieve the remote first, because it's the source of truth, else we retrieve the local (meaning, we're guest, and we created a local document)